### PR TITLE
Implement undo/redo history

### DIFF
--- a/app/calculator.py
+++ b/app/calculator.py
@@ -12,6 +12,7 @@ from app.calculation import Calculation
 from app.exceptions import OperationError, ValidationError
 from app.input_validators import InputValidator
 from app.operations import Operation
+from app.history import History
 
 # Type aliases for better readability
 Number = Union[int, float, Decimal]
@@ -21,10 +22,9 @@ CalculationResult = Union[Number, str]
 class Calculator:
 
     def __init__(self):
-        """
-        Initializes the Calculator with a configuration and no operation strategy.
-        """
+        """Initialize the Calculator and its history manager."""
         self.operation_strategy: Operation = None
+        self.history = History()
         logging.info("Calculator initialized with default configuration.")
         
 
@@ -56,6 +56,9 @@ class Calculator:
                 operand2=validated_b
             )
 
+            # Record the calculation for history management
+            self.history.add_calculation(calculation)
+
             return result
 
         except ValidationError as e:
@@ -66,5 +69,23 @@ class Calculator:
             # Log and raise operation errors for any other exceptions
             logging.error(f"Operation failed: {str(e)}")
             raise OperationError(f"Operation failed: {str(e)}")
+
+    # ------------------------------------------------------------------
+    # History helpers
+    def undo(self) -> None:
+        """Undo the last calculation."""
+        self.history.undo()
+
+    def redo(self) -> None:
+        """Redo the last undone calculation."""
+        self.history.redo()
+
+    def clear_history(self) -> None:
+        """Clear all recorded calculations."""
+        self.history.clear()
+
+    def get_history(self) -> list[Calculation]:
+        """Return a copy of the calculation history."""
+        return self.history.get_history()
 
     

--- a/app/calculator_memento.py
+++ b/app/calculator_memento.py
@@ -1,0 +1,11 @@
+from dataclasses import dataclass
+from typing import List
+
+from app.calculation import Calculation
+
+
+@dataclass
+class CalculatorMemento:
+    """Snapshot of the calculator history state."""
+
+    state: List[Calculation]

--- a/app/calculator_repl.py
+++ b/app/calculator_repl.py
@@ -45,6 +45,32 @@ def calculator_repl():
                     print("Goodbye!")
                     break
 
+                if command == 'history':
+                    for idx, calc_entry in enumerate(calc.get_history(), start=1):
+                        print(f"{idx}: {calc_entry}")
+                    continue
+
+                if command == 'clear':
+                    calc.clear_history()
+                    print("History cleared.")
+                    continue
+
+                if command == 'undo':
+                    try:
+                        calc.undo()
+                        print("Last calculation undone.")
+                    except IndexError:
+                        print("Nothing to undo.")
+                    continue
+
+                if command == 'redo':
+                    try:
+                        calc.redo()
+                        print("Redo successful.")
+                    except IndexError:
+                        print("Nothing to redo.")
+                    continue
+
                 if command in ['add', 'subtract', 'multiply', 'divide', 'power', 'root','int_divide', 'percent', 'abs_dif']:
                     # Perform the specified arithmetic operation
                     try:

--- a/app/history.py
+++ b/app/history.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from typing import List
+
+from app.calculation import Calculation
+from app.calculator_memento import CalculatorMemento
+
+
+class History:
+    """Manages a list of calculations with undo/redo support."""
+
+    def __init__(self) -> None:
+        self._calculations: List[Calculation] = []
+        self._undo_stack: List[CalculatorMemento] = []
+        self._redo_stack: List[CalculatorMemento] = []
+
+    # ------------------------------------------------------------------
+    # Memento helpers
+    def _create_memento(self) -> CalculatorMemento:
+        return CalculatorMemento(self._calculations.copy())
+
+    def _restore_memento(self, memento: CalculatorMemento) -> None:
+        self._calculations = memento.state.copy()
+
+    # ------------------------------------------------------------------
+    # History manipulation
+    def add_calculation(self, calculation: Calculation) -> None:
+        """Add a new calculation and update undo stack."""
+        self._undo_stack.append(self._create_memento())
+        self._calculations.append(calculation)
+        self._redo_stack.clear()
+
+    def clear(self) -> None:
+        self._calculations.clear()
+        self._undo_stack.clear()
+        self._redo_stack.clear()
+
+    def get_history(self) -> List[Calculation]:
+        return self._calculations.copy()
+
+    # ------------------------------------------------------------------
+    # Undo/Redo operations
+    def undo(self) -> None:
+        if not self._undo_stack:
+            raise IndexError("No operations to undo")
+        self._redo_stack.append(self._create_memento())
+        memento = self._undo_stack.pop()
+        self._restore_memento(memento)
+
+    def redo(self) -> None:
+        if not self._redo_stack:
+            raise IndexError("No operations to redo")
+        self._undo_stack.append(self._create_memento())
+        memento = self._redo_stack.pop()
+        self._restore_memento(memento)


### PR DESCRIPTION
## Summary
- track calculations in a History class
- store snapshots of history in CalculatorMemento
- update Calculator to record calculations and expose undo/redo
- extend the REPL to handle history commands

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68606d8c5060832192fd84ef607324da